### PR TITLE
Add var logic for schema prefix

### DIFF
--- a/models/_cms_hcc_models.yml
+++ b/models/_cms_hcc_models.yml
@@ -4,7 +4,9 @@ models:
 # Final
   - name: cms_hcc__patient_risk_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: patient_risk_factors
       tags: cms_hcc
       materialized: table
@@ -39,7 +41,9 @@ models:
 
   - name: cms_hcc__patient_risk_scores
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: patient_risk_scores
       tags: cms_hcc
       materialized: table
@@ -74,7 +78,9 @@ models:
 # Intermediate
   - name: cms_hcc__int_demographic_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_demographic_factors
       tags: cms_hcc
       materialized: table
@@ -132,7 +138,9 @@ models:
 
   - name: cms_hcc__int_disabled_interaction_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_disabled_interaction_factors
       tags: cms_hcc
       materialized: table
@@ -158,7 +166,9 @@ models:
 
   - name: cms_hcc__int_disease_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_disease_factors
       tags: cms_hcc
       materialized: table
@@ -187,7 +197,9 @@ models:
 
   - name: cms_hcc__int_disease_interaction_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_disease_interaction_factors
       tags: cms_hcc
       materialized: table
@@ -218,7 +230,9 @@ models:
 
   - name: cms_hcc__int_enrollment_interaction_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_enrollment_interaction_factors
       tags: cms_hcc
       materialized: table
@@ -244,7 +258,9 @@ models:
 
   - name: cms_hcc__int_hcc_count_factors
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_hcc_count_factors
       tags: cms_hcc
       materialized: table
@@ -270,7 +286,9 @@ models:
 
   - name: cms_hcc__int_hcc_hierarchy
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_hcc_hierarchy
       tags: cms_hcc
       materialized: table
@@ -292,7 +310,9 @@ models:
 
   - name: cms_hcc__int_hcc_mapping
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_hcc_mapping
       tags: cms_hcc
       materialized: table
@@ -316,7 +336,9 @@ models:
 
   - name: cms_hcc__int_prep_conditions
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_prep_conditions
       tags: cms_hcc
       materialized: view
@@ -340,7 +362,9 @@ models:
 
   - name: cms_hcc__int_prep_eligibility
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _int_prep_eligibility
       tags: cms_hcc
       materialized: view

--- a/seeds/_seeds.yml
+++ b/seeds/_seeds.yml
@@ -6,7 +6,9 @@ seeds:
       Adjustment rates by payment year. Extracted from rate announcement
       documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_adjustment_rates
       tags: cms_hcc
       column_types:
@@ -17,7 +19,9 @@ seeds:
       CPT/HCPCS encounter filtering included list by payment year. Combined 
       and cleaned version of code files on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_cpt_hcpcs
       tags: cms_hcc
       column_types:
@@ -29,7 +33,9 @@ seeds:
       Demographic factors by model version and risk segment. Extracted from 
       rate announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_demographic_factors
       tags: cms_hcc
       column_types:
@@ -40,7 +46,9 @@ seeds:
       Disease and disabled interaction factors by model version 
       and risk segment. Extracted from rate announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_disabled_interaction_factors
       tags: cms_hcc
       column_types:
@@ -53,7 +61,9 @@ seeds:
       Disease factors by model version and risk segment. Extracted from rate 
       announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_disease_factors
       tags: cms_hcc
       column_types:
@@ -66,7 +76,9 @@ seeds:
       Disease hierarchies by model version. Extracted from rate announcement
       documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_disease_hierarchy
       tags: cms_hcc
       column_types:
@@ -80,7 +92,9 @@ seeds:
       Disease interaction factors by model version and risk segment. Extracted 
       from rate announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_disease_interaction_factors
       tags: cms_hcc
       column_types:
@@ -95,7 +109,9 @@ seeds:
       Enrollment interaction factors by model version and risk segment. 
       Extracted from rate announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_enrollment_interaction_factors
       tags: cms_hcc
       column_types:
@@ -106,7 +122,9 @@ seeds:
       ICD-10 to HCC mapping by payment year and model version. Combined and 
       cleaned version of code files on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_icd_10_cm_mappings
       tags: cms_hcc
       column_types:
@@ -120,7 +138,9 @@ seeds:
       Payment HCC count factors by model version and risk segment. Extracted 
       from rate announcement documents on cms.gov.
     config:
-      schema: cms_hcc
+      schema: |
+        {%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc
+        {% else %}cms_hcc{%- endif -%}
       alias: _value_set_payment_hcc_count_factors
       tags: cms_hcc
       column_types:

--- a/snapshots/cms_hcc__patient_risk_factors_snapshot.sql
+++ b/snapshots/cms_hcc__patient_risk_factors_snapshot.sql
@@ -1,8 +1,12 @@
 {% snapshot cms_hcc__patient_risk_factors_snapshot %}
 
+{% set schema_var %}
+{%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc{% else %}cms_hcc{%- endif -%}
+{% endset %}
+
 {{
   config({
-      "target_schema": "cms_hcc"
+      "target_schema": schema_var
     , "alias": "patient_risk_factors_snapshot"
     , "tags": "cms_hcc"
     , "strategy": "timestamp"

--- a/snapshots/cms_hcc__patient_risk_scores_snapshot.sql
+++ b/snapshots/cms_hcc__patient_risk_scores_snapshot.sql
@@ -1,8 +1,12 @@
 {% snapshot cms_hcc__patient_risk_scores_snapshot %}
 
+{% set schema_var %}
+{%- if var('tuva_schema_prefix',None) != None -%}{{var('tuva_schema_prefix')}}_cms_hcc{% else %}cms_hcc{%- endif -%}
+{% endset %}
+
 {{
   config({
-      "target_schema": "cms_hcc"
+      "target_schema": schema_var
     , "alias": "patient_risk_scores_snapshot"
     , "tags": "cms_hcc"
     , "strategy": "timestamp"


### PR DESCRIPTION
## Describe your changes

Replaces hard-coded schema with logic to use a prefix if the `tuva_schema_prefix` var is used. This follows functionality set in the Tuva Project.

## How has this been tested?

Tested with `dbt build`.

## Reviewer focus

n/a

## Checklist before requesting a review

- [ ]  I have recorded a Loom performing a self-review of my code
- [x]  My code follows style guidelines
- [ ]  I have commented my code as necessary
- [x ]  My code `dbt build` without errors in Snowflake
- [ ]  My code `dbt build` without errors in Redshift
- [ ]  I have implemented generic dbt tests to validate primary keys/uniqueness in my model
- [ ]  I have updated dbt docs by running `dbt docs generate` and copying the appropriate files to the `docs/` path

## (Optional) Gif of how this PR makes you feel

![](url)

## Loom link
